### PR TITLE
fix: Animate pseudo-element instead of border

### DIFF
--- a/src/components/SimpleCard.js
+++ b/src/components/SimpleCard.js
@@ -8,6 +8,7 @@ const SimpleCard = props => {
   return (
     <div
       css={css({
+        position: 'relative',
         gridColumn: '1/4',
         border: '1px solid rgba(52, 61, 68, 0.05)',
         transition: props.hover
@@ -21,7 +22,7 @@ const SimpleCard = props => {
         width: props.width ? props.width : '100%',
         maxWidth: props.maxWidth ? props.maxWidth : '100%',
         borderRadius: '6px',
-        'p, h1, h2, h3, h4, h5, h6, span, button' : {
+        'p, h1, h2, h3, h4, h5, h6, span, button': {
           textAlign: props.textcenter ? 'center' : null,
           margin: props.center ? '0.8em auto 0' : null,
         },
@@ -30,14 +31,25 @@ const SimpleCard = props => {
           : '0 4px 10px -4px rgba(0,0,0,0.15)',
         ':hover': {
           transform: props.hover ? 'scale(1.015)' : null,
-          borderTop: props.hover
-            ? `2px solid ${theme.colors.lightOrange}`
-            : null,
           borderRadius: props.hover ? '0px 0px 6px 6px' : null,
           boxShadow: props.hover ? '0 10px 30px -10px rgba(0,0,0,0.15)' : null,
           p: {
             transition: 'all 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0s;',
           },
+          '::before': {
+            backgroundColor: props.hover ? theme.colors.lightOrange : null,
+          },
+        },
+        '::before': {
+          position: 'absolute',
+          content: '" "',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '2px',
+          backgroundColor: 'transparent',
+          transition:
+            'background-color 0.8s cubic-bezier(0.2, 0.8, 0.2, 1) 0s;',
         },
       })}
       {...props}


### PR DESCRIPTION
Hi Maggie,

Submitting a PR to your personal website seems a bit intrusive, but at the least it can provide a little notification of something you may have been unaware of.

When hovered, the SimpleTile component's top border gets animated from 1px to 2px (turning orange), this causes the whole website to jostle up and down to accommodate the extra pixel. It's most noticeable on the [Digital Garden](https://maggieappleton.com/garden) page, as it causes a bit of a performance hit.

This PR replaces the border animation with a psuedo-element as the orange decoration. It has the same visual effect and animation just without the jostle.

Just found your work today - it's amazing. Your metaphors on metaphors in your latest essay were really insightful. I've got plenty of great articles to read up on, so thanks a bunch for doing what you do! 👍